### PR TITLE
Don't let the cert set the groups

### DIFF
--- a/create-user-cert.sh
+++ b/create-user-cert.sh
@@ -18,8 +18,6 @@ k8s_cluster_domain=${k8s_cluster_domain#*:\/\/}
 
 
 : "${K8S_USER:?must be set}"
-: "${K8S_GROUPS:?must be set}"
-: "${K8S_CLUSTER:?must be set}"
 
 current_dir="${PWD}"
 working_dir=$(mktemp -d)
@@ -31,19 +29,15 @@ echo ${working_dir}
 if [[ -z ${USER_CSR} ]] ; then
 	export USER_CSR="${tmp_dir}/${K8S_USER}.csr"
 	echo "Generating the user cert. Consider the user supplying a CSR to the USER_CSR env rather as this is like generating a users password :(" >&2
-	echo '   They can generate one by running `openssl genrsa -out "${USER}.key" 4098` followed by `openssl req -new -key "${USER}.key" -out "${USER}.csr" -subj "/CN=${USER}/O=developer"`'
+	echo '   They can generate one by running `openssl genrsa -out "${USER}.key" 4098` followed by `openssl req -new -key "${USER}.key" -out "${USER}.csr" -subj "/CN=${USER}"`'
 	sleep 5
 	openssl genrsa -out "${K8S_USER}.key" 2048
-	O='O='$(echo "${K8S_GROUPS}" | sed 's/,/\/O=/g')
-	openssl req -new -key "${K8S_USER}.key" -out "${USER_CSR}" -subj "/CN=${K8S_USER}/${O}"
+	openssl req -new -key "${K8S_USER}.key" -out "${USER_CSR}" -subj "/CN=${K8S_USER}"
 fi
 
-# Check subject matches user and groups
+# Check subject matches user
 
 REQ_SUBJECT="$(openssl req -noout -in ${USER_CSR} -subject)"
-for group in ${K8S_GROUPS//,/ } ; do
-	REQ_SUBJECT=${REQ_SUBJECT/\/O=${group}}
-done
 echo "${REQ_SUBJECT}" | grep "^subject=\/CN=${K8S_USER}$" || { echo "Subject doesn't match expected subject"; exit 1 ; }
 
 cat <<EOF | kubectl create -f -
@@ -61,6 +55,8 @@ USER_CERT="${K8S_USER}.${k8s_cluster_domain}.crt"
 CLUSTER_CERT="${k8s_cluster_domain}.crt"
 
 kubectl get csr "${K8S_USER}" -o jsonpath='{.status.certificate}' |  base64 --decode > "${USER_CERT}"
+
+kubectl create rolebinding "${K8S_USER}-cluster-admin" --clusterrole=cluster-admin "--user=${K8S_USER}" --namespace=apps
 
 openssl s_client -showcerts -connect "api.${k8s_cluster_domain}:443" </dev/null 2>/dev/null | openssl x509 > "${CLUSTER_CERT}"
 


### PR DESCRIPTION
Why? Turns out k8s has no way to revoke certs so adding peeps to a group
like `developers` at the cert level means if someone leaves you'd have
to create a group called `developers2` and re-issue everyone remaining
with certs in that group, and remove the `deveopers` groups access rights
to revoke the leavers access.