### PR TITLE
Improve app-namespace user creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Share the following  two commands with the user to have them generate a key.
 ## Create, sign and zip up user creds
 ```
 $ export K8S_USER=jim
-$ export K8S_GROUPS=developer
-$ export K8S_CLUSTER=dev.k8s.example.com
+$ export K8S_NAMESPACE=apps
+$ export K8S_ADMIN=0  # 0 for no admin rights, 1 for cluster admin
 $ export USER_CSR=/tmp/jim.csr ## This is optional but encouraged, keys will be generated if no CSR is supplied
 $ ./create-user-cert.sh
 ```

--- a/role-user.yaml
+++ b/role-user.yaml
@@ -2,9 +2,9 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: ${NAMESPACE}
-  name: ${USER}
+  namespace: ${K8S_NAMESPACE}
+  name: ${K8S_USER}
 rules:
 - apiGroups: [""]
-  resources: ["deployments", "replicasets", "pods"]
+  resources: ["deployments", "replicasets", "pods", "pods/attach", "pods/log"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"] # You can also use ["*"]

--- a/rolebinding-user.yaml
+++ b/rolebinding-user.yaml
@@ -2,13 +2,13 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: ${USER}-binding
-  namespace: ${NAMESPACE}
+  name: ${K8S_USER}-binding
+  namespace: ${K8S_NAMESPACE}
 subjects:
 - kind: User
-  name: ${USER}
+  name: ${K8S_USER}
   apiGroup: ""
 roleRef:
   kind: Role
-  name: ${USER}
+  name: ${K8S_USER}
   apiGroup: ""


### PR DESCRIPTION
- Make admin privs optional - we may not want users to have admin access
to a namespace
- Make namespace configurable - most clients do not have one 'apps'
namespace, but a variety of namespcaes for their environments
- Customise role-user.yaml so users can use it to exec/run pods, a common
troubleshooting approach
- Use consistent K8S_ variable names, so the same environment can be
used to run the script, but also to envsubst the config.

Great job though, this was very easy to use!